### PR TITLE
Add Document.Root() for top level access

### DIFF
--- a/dj/dj.go
+++ b/dj/dj.go
@@ -53,11 +53,6 @@ func Parse(r io.Reader) (*Document, error) {
 	}, nil
 }
 
-// Len returns the number of elements on the root level of the document.
-func (d *Document) Len() int {
-	return nodeLen(d.root)
-}
-
 // At retrieves a value at a given path of keys.
 func (d *Document) At(path ...string) *Value {
 	data, err := nodeAt(d.root, []string{}, path)
@@ -65,6 +60,12 @@ func (d *Document) At(path ...string) *Value {
 		return newValue(path, nil, err)
 	}
 	return newValue(path, data, nil)
+}
+
+// Root is a convenience varient of At() for the highest
+// level value.
+func (d *Document) Root() *Value {
+	return newValue([]string{}, d.root, nil)
 }
 
 // EOF

--- a/dj/dj_test.go
+++ b/dj/dj_test.go
@@ -183,4 +183,48 @@ func TestDocumentAt(t *testing.T) {
 	}
 }
 
+// TestDocumentRoot verifies the access to the root value of a document.
+func TestDocumentRoot(t *testing.T) {
+	assert := asserts.NewTesting(t, asserts.FailStop)
+
+	tests := []struct {
+		name     string
+		in       string
+		nodeType dj.NodeType
+		err      string
+	}{
+		{
+			"single string value",
+			`"test"`,
+			dj.NodeTypeString,
+			"",
+		}, {
+			"list document",
+			`["1", "2", "3", "4", "5"]`,
+			dj.NodeTypeArray,
+			"",
+		}, {
+			"nested document",
+			`{"s": "string","o":{"x":"foo","a":["1","2","3","4","5"]}}`,
+			dj.NodeTypeObject,
+			"",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			defer assert.SetFailable(t)()
+			b := bytes.NewBufferString(test.in)
+			doc, err := dj.Parse(b)
+			assert.NoError(err)
+			value := doc.Root()
+			if test.err != "" {
+				assert.ErrorContains(value.Error(), test.err)
+			} else {
+				assert.Equal(value.Type(), test.nodeType)
+			}
+		})
+	}
+}
+
 // EOF

--- a/dj/dj_test.go
+++ b/dj/dj_test.go
@@ -31,7 +31,7 @@ func TestNewDocument(t *testing.T) {
 	assert.NotNil(doc)
 }
 
-// TestParseDocument verifies the reading and parsing of an documents.
+// TestParseDocument verifies the parsing of a document.
 func TestParseDocument(t *testing.T) {
 	assert := asserts.NewTesting(t, asserts.FailStop)
 
@@ -99,7 +99,7 @@ func TestParseDocument(t *testing.T) {
 			} else {
 				assert.NoError(err)
 				assert.NotNil(doc)
-				assert.Length(doc, test.length)
+				assert.Length(doc.Root(), test.length)
 			}
 		})
 	}

--- a/dj/doc.go
+++ b/dj/doc.go
@@ -13,7 +13,7 @@
 //     if err != nil {
 //         ...
 //     }
-//     firstStreet := myCustomer.At("addresses", "#0", "street").AsString()
+//     firstStreet := myCustomer.At("addresses", "#0", "street").AsString("default")
 //
 // The value passed to AsString() will panic if an access does not match (the
 // hard way) or return the default value for the type if the value is nil. And

--- a/dj/node.go
+++ b/dj/node.go
@@ -17,8 +17,46 @@ import (
 )
 
 //--------------------
+// CONSTANTS
+//--------------------
+
+// NodeType describe the JSON type of node, may it be the
+// root or any lower one.
+type NodeType int
+
+const (
+	NodeTypeNull NodeType = iota
+	NodeTypeObject
+	NodeTypeArray
+	NodeTypeString
+	NodeTypeNumber
+	NodeTypeBool
+)
+
+//--------------------
 // NODE HELPERS
 //--------------------
+
+// nodeType determines the JSON type of a node (root or value).
+func nodeType(data interface{}) NodeType {
+	if data == nil {
+		return NodeTypeNull
+	}
+	switch data.(type) {
+	case map[string]interface{}:
+		return NodeTypeObject
+	case []interface{}:
+		return NodeTypeArray
+	case string:
+		return NodeTypeString
+	case int, float64:
+		return NodeTypeNumber
+	case bool:
+		return NodeTypeBool
+	}
+	panic("invalid node type")
+
+}
 
 // nodeLen returns the length of the passed data (which can be a single
 // value too).

--- a/dj/value.go
+++ b/dj/value.go
@@ -19,23 +19,6 @@ import (
 )
 
 //--------------------
-// CONSTANTS
-//--------------------
-
-// ValueType defines the type of a value.
-type ValueType int
-
-const (
-	ValueTypeNull ValueType = iota
-	ValueTypeObject
-	ValueTypeArray
-	ValueTypeString
-	ValueTypeInt
-	ValueTypeFloat64
-	ValueTypeBool
-)
-
-//--------------------
 // VALUE
 //--------------------
 
@@ -83,26 +66,15 @@ func (v *Value) IsUndefined() bool {
 	return v.data == nil
 }
 
-// Type returns the type of the value.
-func (v *Value) Type() ValueType {
-	if v.data == nil {
-		return ValueTypeNull
-	}
-	switch v.data.(type) {
-	case map[string]interface{}:
-		return ValueTypeObject
-	case []interface{}:
-		return ValueTypeArray
-	case string:
-		return ValueTypeString
-	case int:
-		return ValueTypeInt
-	case float64:
-		return ValueTypeFloat64
-	case bool:
-		return ValueTypeBool
-	}
-	panic("invalid value type")
+// Type returns the JSON type of the value.
+func (v *Value) Type() NodeType {
+	return nodeType(v.data)
+}
+
+// Len return 1 in case of simple value types of the number of
+// elements in case of objects or arrays.
+func (v *Value) Len() int {
+	return nodeLen(v.data)
 }
 
 // AsString returns the value as string.

--- a/dj/value_test.go
+++ b/dj/value_test.go
@@ -113,28 +113,28 @@ func TestValueTests(t *testing.T) {
 
 	v := dj.NewValue(emptyPath, nil, nil)
 	assert.True(v.IsUndefined())
-	assert.Equal(v.Type(), dj.ValueTypeNull)
+	assert.Equal(v.Type(), dj.NodeTypeNull)
 
 	v.Set("test")
 	assert.False(v.IsUndefined())
 
 	v = dj.NewValue(emptyPath, map[string]interface{}{}, nil)
-	assert.Equal(v.Type(), dj.ValueTypeObject)
+	assert.Equal(v.Type(), dj.NodeTypeObject)
 
 	v = dj.NewValue(emptyPath, []interface{}{}, nil)
-	assert.Equal(v.Type(), dj.ValueTypeArray)
+	assert.Equal(v.Type(), dj.NodeTypeArray)
 
 	v = dj.NewValue(emptyPath, "test", nil)
-	assert.Equal(v.Type(), dj.ValueTypeString)
+	assert.Equal(v.Type(), dj.NodeTypeString)
 
 	v = dj.NewValue(emptyPath, 12345, nil)
-	assert.Equal(v.Type(), dj.ValueTypeInt)
+	assert.Equal(v.Type(), dj.NodeTypeInt)
 
 	v = dj.NewValue(emptyPath, 12.345, nil)
-	assert.Equal(v.Type(), dj.ValueTypeFloat64)
+	assert.Equal(v.Type(), dj.NodeTypeFloat64)
 
 	v = dj.NewValue(emptyPath, true, nil)
-	assert.Equal(v.Type(), dj.ValueTypeBool)
+	assert.Equal(v.Type(), dj.NodeTypeBool)
 }
 
 // TestValueIteration verifies the iteration over value data.

--- a/dj/value_test.go
+++ b/dj/value_test.go
@@ -107,8 +107,8 @@ func TestValueSetting(t *testing.T) {
 	assert.ErrorContains(v.Error(), "invalid type")
 }
 
-// TestValueTests verifies testing of values.
-func TestValueTests(t *testing.T) {
+// TestValueTypes verifies testing of values.
+func TestValueTypes(t *testing.T) {
 	assert := asserts.NewTesting(t, asserts.FailStop)
 
 	v := dj.NewValue(emptyPath, nil, nil)
@@ -128,10 +128,10 @@ func TestValueTests(t *testing.T) {
 	assert.Equal(v.Type(), dj.NodeTypeString)
 
 	v = dj.NewValue(emptyPath, 12345, nil)
-	assert.Equal(v.Type(), dj.NodeTypeInt)
+	assert.Equal(v.Type(), dj.NodeTypeNumber)
 
 	v = dj.NewValue(emptyPath, 12.345, nil)
-	assert.Equal(v.Type(), dj.NodeTypeFloat64)
+	assert.Equal(v.Type(), dj.NodeTypeNumber)
 
 	v = dj.NewValue(emptyPath, true, nil)
 	assert.Equal(v.Type(), dj.NodeTypeBool)


### PR DESCRIPTION
Also improve the `Value` type.

Solves #13 